### PR TITLE
fix: Make sure the backend and front end are available before launching nginx

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
       - {{cookiecutter.port}}:80
+    depends_on:
+      - backend
+      - frontend
 
   redis:
     image: redis


### PR DESCRIPTION
Currently this may in some cases cause nginx to fail at startup, with error: 
```
nginx_1     | 2020/07/08 06:13:44 [emerg] 1#1: host not found in upstream "backend" in /etc/nginx/conf.d/default.conf:24
nginx_1     | nginx: [emerg] host not found in upstream "backend" in /etc/nginx/conf.d/default.conf:24
```
