### PR TITLE
Wait for Postgres to become available instead of naively sleeping before running Alembic migrations

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,7 +5,7 @@ update_configs:
   - package_manager: 'javascript'
     directory: '{{cookiecutter.project_slug}}/frontend'
     update_schedule: 'monthly'
-  # Keep Dockerfile up to date, batching pull requests weekly
+  # Keep Dockerfile up to date, batching pull requests monthly
   - package_manager: 'python'
     directory: '{{cookiecutter.project_slug}}/backend'
     update_schedule: 'monthly'

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,9 @@
 version: 1
 update_configs:
+  # Keep submodules up to date, batching pull requests monthly
+  - package_manager: 'submodules'
+    directory: '/extern'
+    update_schedule: 'monthly'
   # Keep package.json (& lockfiles) up to date as soon as
   # new versions are published to the npm registry
   - package_manager: 'javascript'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/wait-for-it"]
+	path = extern/wait-for-it
+	url = git@github.com:vishnubob/wait-for-it.git

--- a/{{cookiecutter.project_slug}}/scripts/build.sh
+++ b/{{cookiecutter.project_slug}}/scripts/build.sh
@@ -3,11 +3,9 @@
 # Build and run containers
 docker-compose up -d
 
-# Hack to wait for postgres container to be up before running alembic migrations
-sleep 5;
-
-# Run migrations
-docker-compose run --rm backend alembic upgrade head
+# Wait 10 seconds for postgres service to appear on port 5432, then run alembic migrations
+extern/wait-for-it/wait-for-it.sh postgres:5432 --strict --timeout=10 \
+    -- docker-compose run --rm backend alembic upgrade head
 
 # Create initial data
 docker-compose run --rm backend python3 app/initial_data.py


### PR DESCRIPTION
Wait for the `postgres` Docker Compose service to become available instead of naively sleeping for 5 seconds before running Alembic migrations. Implemented using the popular `wait-for-it.sh` script (added to the repo as a git submodule).