### PR TITLE
Update docker-compose.yml

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: backend
       dockerfile: Dockerfile
-    command: celery worker -A app.tasks --loglevel=DEBUG -Q main-queue -c 1
+    command: celery -A app.tasks worker --loglevel=DEBUG -Q main-queue -c 1
 
   flower:  
     image: mher/flower

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: backend
       dockerfile: Dockerfile
-    command: celery -A app.tasks worker --loglevel=DEBUG -Q main-queue -c 1
+    command: celery --app app.tasks worker --loglevel=DEBUG -Q main-queue -c 1
 
   flower:  
     image: mher/flower


### PR DESCRIPTION
In Celery 5.0, -A or --app should come first, as a global option. Running celery worker -A results in the following output:

"You are using `-A` as an option of the worker sub-command:
celery worker -A celeryapp <...>

The support for this usage was removed in Celery 5.0. Instead you should use `-A` as a global option:
celery -A celeryapp worker <...>"