### PR TITLE
Fix node version at 12

### DIFF
--- a/{{cookiecutter.project_slug}}/frontend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:12
 
 ADD package.json /package.json
 


### PR DESCRIPTION
Got "callstack size exceeded" when using `node:latest`. `node:12` is supposed to be more stable, as suggested by @pigeonflight in https://github.com/Buuntu/fastapi-react/issues/136#issuecomment-716910397