### PR TITLE
Add support for latest flower with celery 5

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   flower:  
     image: mher/flower
-    command: flower --broker=redis://redis:6379/0 --port=5555
+    command: celery flower --broker=redis://redis:6379/0 --port=5555
     ports:  
         - 5555:5555
     depends_on:


### PR DESCRIPTION
From version 1.0.1, Flower uses Celery 5 and has to be invoked in the same style as celery commands do.

This should let anyone cloning this project now to have it working correctly. If not, they will receive a
```
Docker – “flower”: executable file not found in $PATH: unknown
```
error

For more info, see: https://stackoverflow.com/questions/68267953/docker-flower-executable-file-not-found-in-path-unknown