### PR TITLE
feat: upgrade sqlalchemy to 1.4

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/alembic.ini
+++ b/{{cookiecutter.project_slug}}/backend/app/alembic.ini
@@ -7,6 +7,10 @@ script_location = alembic
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
 
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
 # timezone to use when rendering the date
 # within the migration file as well as the filename.
 # string value is passed to dateutil.tz.gettz()
@@ -31,12 +35,19 @@ script_location = alembic
 # directories, initial revisions must be specified with --version-path
 # version_locations = %(here)s/bar %(here)s/bat alembic/versions
 
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. Valid values are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os  # default: use os.pathsep
+
 # the output encoding used when revision files
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = driver://user:pass@localhost/dbname
-
+sqlalchemy.url = driver://user:pass@localhost/dbname # will be replaced by environment variable called `DATABASE_URL`.
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/{{cookiecutter.project_slug}}/backend/app/alembic/env.py
+++ b/{{cookiecutter.project_slug}}/backend/app/alembic/env.py
@@ -1,11 +1,13 @@
+import asyncio
 import os
-from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from app.db.models import Base
+from logging.config import fileConfig
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -53,29 +55,34 @@ def run_migrations_offline():
         context.run_migrations()
 
 
-def run_migrations_online():
+def do_run_migrations(connection):
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online():
     """Run migrations in 'online' mode.
     In this scenario we need to create an Engine
     and associate a connection with the context.
     """
     configuration = config.get_section(config.config_ini_section)
     configuration["sqlalchemy.url"] = get_url()
-    connectable = engine_from_config(
-        configuration,
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
+    connectable = AsyncEngine(
+        engine_from_config(
+            configuration,
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+            future=True,  # enforce the v2.0 style
+        )
     )
 
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
-
-        with context.begin_transaction():
-            context.run_migrations()
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
 
 
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    run_migrations_online()
+    asyncio.run(run_migrations_online())

--- a/{{cookiecutter.project_slug}}/backend/app/db/session.py
+++ b/{{cookiecutter.project_slug}}/backend/app/db/session.py
@@ -1,10 +1,10 @@
-from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from app.core import config
 
-engine = create_engine(
+engine = create_async_engine(
     config.SQLALCHEMY_DATABASE_URI,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/{{cookiecutter.project_slug}}/backend/conftest.py
+++ b/{{cookiecutter.project_slug}}/backend/conftest.py
@@ -1,5 +1,6 @@
 import pytest
-from sqlalchemy import create_engine, event
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import database_exists, create_database, drop_database
 from fastapi.testclient import TestClient
@@ -22,7 +23,7 @@ def test_db():
     This is to avoid tests affecting the database state of other tests.
     """
     # Connect to the test database
-    engine = create_engine(
+    engine = create_async_engine(
         get_test_db_url(),
     )
 
@@ -63,7 +64,7 @@ def create_test_db():
         test_db_url
     ), "Test database already exists. Aborting tests."
     create_database(test_db_url)
-    test_engine = create_engine(test_db_url)
+    test_engine = create_async_engine(test_db_url)
     Base.metadata.create_all(test_engine)
 
     # Run the tests

--- a/{{cookiecutter.project_slug}}/backend/requirements.txt
+++ b/{{cookiecutter.project_slug}}/backend/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.4.3
+asyncpg==0.25.0
 Authlib==0.14.3
 fastapi==0.65.2
 celery==5.0.0
@@ -10,10 +11,10 @@ Jinja2==2.11.3
 psycopg2==2.8.6
 pytest==6.1.0
 requests==2.24.0
-SQLAlchemy==1.3.19
+SQLAlchemy==1.4.29
 uvicorn==0.12.1
 passlib==1.7.2
 bcrypt==3.2.0
-sqlalchemy-utils==0.36.8
+sqlalchemy-utils==0.38.2
 python-multipart==0.0.5
 pyjwt==1.7.1

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - {{cookiecutter.port}}:80
+      - "{{cookiecutter.port}}:80"
     depends_on:
       - backend
       - frontend
@@ -32,10 +32,10 @@ services:
       dockerfile: Dockerfile
     command: celery --app app.tasks worker --loglevel=DEBUG -Q main-queue -c 1
 
-  flower:  
+  flower:
     image: mher/flower
     command: celery flower --broker=redis://redis:6379/0 --port=5555
-    ports:  
+    ports:
         - 5555:5555
     depends_on:
       - "redis"
@@ -51,7 +51,7 @@ services:
       - ./.docker/.ipython:/root/.ipython:cached
     environment:
       PYTHONPATH: .
-      DATABASE_URL: 'postgresql://{{cookiecutter.postgres_user}}:{{cookiecutter.postgres_password}}@postgres:5432/{{cookiecutter.postgres_user}}'
+      DATABASE_URL: 'postgresql+asyncpg://{{cookiecutter.postgres_user}}:{{cookiecutter.postgres_password}}@postgres:5432/{{cookiecutter.postgres_user}}'
     depends_on:
       - "postgres"
 


### PR DESCRIPTION
Closes #181 

---

### Summary

- [x] Update SQLAlchemy to v1.4.
- [x] Update SQLAlchemy-Utils to 0.38.2 (supports SQLAlchemy v1.4).
- [x] Add asyncpg to dependencies; this is a required driver to work with SQLAlchemy's `create_async_driver`.
- [x] Update instantiation of session engine with SQLAlchemy's `create_async_driver`.
- [ ] Update tests to connect to database asynchronously.

### Questions

1. Should we explicitly add `greenlet` as another dependency? It doesn't seem to cause issues in Docker, but may be required in some local contexts.
2. Would you like me to fix tests to work with the synchronous drivers or update all tests to work with `asyncio` (i.e., ORM's new async driver and asyncpg)?